### PR TITLE
Support 64 bit data when parsing counter values.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
         - 1.8.x
         - stable
 script:
+        - go get -t ./...
         - go test ./...
         - go tool vet .
         - go tool vet ./lib

--- a/lib/parser.go
+++ b/lib/parser.go
@@ -44,7 +44,7 @@ const (
 	reClassHeaderStr = "class (?P<className>[a-zA-Z_]+) (?P<qdiscHandle>[0-9a-f]+):(?P<classHandle>[0-9a-f]+).*"
 
 	// reStatsStr is string version of the RE to match the Qdisc and Class statisticsin TC output.
-	reStatsStr = " Sent (?P<sentBytes>[0-9]+) bytes (?P<sentPkt>[0-9]+) pkt .dropped (?P<droppedPkt>[0-9]+), overlimits (?P<overLimitPkt>[0-9]+) requeues 0."
+	reStatsStr = " Sent (?P<sentBytes>[0-9]+) bytes (?P<sentPkt>[0-9]+) pkt .dropped (?P<droppedPkt>[0-9]+), overlimits (?P<overLimitPkt>[0-9]+) requeues"
 )
 
 // These variables are the default options used by tcParser.
@@ -311,13 +311,13 @@ func (t *tcParser) parseData(cmdOutput string, ifaceName string, reHeader, reDat
 		// Does this line contain the header ?
 		if match := reHeader.FindAllStringSubmatch(line, -1); match != nil {
 			matchSlice := match[0]
-			qdiscHandle, err = strconv.ParseInt(matchSlice[2], 16, 32)
+			qdiscHandle, err = strconv.ParseInt(matchSlice[2], 16, 64)
 			if err != nil {
 				return err
 			}
 			// Class handle is only present in the output for a Class. We assume zero in the output for a Qdisc.
 			if len(matchSlice) == 4 {
-				classHandle, err = strconv.ParseInt(matchSlice[3], 16, 32)
+				classHandle, err = strconv.ParseInt(matchSlice[3], 16, 64)
 				if err != nil {
 					return err
 				}
@@ -332,15 +332,15 @@ func (t *tcParser) parseData(cmdOutput string, ifaceName string, reHeader, reDat
 			if err != nil {
 				return err
 			}
-			sentPkt, err = strconv.ParseInt(matchSlice[2], 10, 32)
+			sentPkt, err = strconv.ParseInt(matchSlice[2], 10, 64)
 			if err != nil {
 				return err
 			}
-			droppedPkt, err = strconv.ParseInt(matchSlice[3], 10, 32)
+			droppedPkt, err = strconv.ParseInt(matchSlice[3], 10, 64)
 			if err != nil {
 				return err
 			}
-			overLimitPkt, err = strconv.ParseInt(matchSlice[4], 10, 32)
+			overLimitPkt, err = strconv.ParseInt(matchSlice[4], 10, 64)
 			if err != nil {
 				return err
 			}

--- a/lib/snmp_test.go
+++ b/lib/snmp_test.go
@@ -27,10 +27,10 @@ func TestSnmpLogIfDebug(t *testing.T) {
 	testData := []struct {
 		debug   bool
 		message string
-		expInfo string
+		expInfo []string
 	}{
-		{false, "message", ""},
-		{true, "message", "message"},
+		{false, "message", nil},
+		{true, "message", []string{"message"}},
 	}
 
 	var o *SnmpOptions

--- a/lib/testdata/tc_class_large_values
+++ b/lib/testdata/tc_class_large_values
@@ -1,0 +1,3 @@
+class prio 2:1 parent 2: leaf 3: 
+ Sent 4791659924495 bytes 4791659924496 pkt (dropped 4791659924497, overlimits 4791659924498 requeues 4791659924499) 
+ backlog 0b 0p requeues 0 

--- a/lib/testdata/tc_qdisc_large_values
+++ b/lib/testdata/tc_qdisc_large_values
@@ -1,0 +1,3 @@
+qdisc dsmark 1: root refcnt 2 indices 0x0020 default_index 0x0000 
+ Sent 4791659924490 bytes 4791659924491 pkt (dropped 4791659924492, overlimits 4791659924493 requeues 4791659924494) 
+ backlog 0b 0p requeues 0 


### PR DESCRIPTION
Also:
- updating data regexp to not match on only on zero requeues.
- using pretty to print test values instead of custom comparator.
- updating TestTcParserParse to be more aligned with the Go style.
- travis build now gets Go dependencies.

Fixes #5 